### PR TITLE
Use db instead of rails cache

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,12 @@ RSpec/StubbedMock:
 RSpec/LetSetup:
   Enabled: false
 
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/ExampleLength:
+  Max: 8
+
 Layout/LineLength:
   Max: 100
   # To make it possible to copy or click on URIs in the code, we allow lines

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'httparty', '~> 0.21.0'
 group :development, :test do
   gem 'byebug', '~> 11.1.3'
   gem 'dotenv-rails'
+  gem 'factory_bot_rails'
   gem 'rspec-html-matchers', '~> 0.10.0'
   gem 'rspec-rails', '~> 5.1', '>= 5.1.2'
   gem 'rubocop-rails'
@@ -81,5 +82,6 @@ group :test do
   gem 'capybara-screenshot', '~> 1.0.26'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 5.3.0'
+  gem 'timecop'
   gem 'webdrivers', '~> 5.3.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,11 @@ GEM
       dotenv (= 3.1.4)
       railties (>= 6.1)
     erubi (1.13.0)
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.1)
@@ -261,6 +266,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     thor (1.3.2)
+    timecop (0.9.8)
     timeout (0.4.1)
     turbo-rails (2.0.10)
       actionpack (>= 6.0.0)
@@ -300,6 +306,7 @@ DEPENDENCIES
   capybara-screenshot (~> 1.0.26)
   city-state (~> 1.1.0)
   dotenv-rails
+  factory_bot_rails
   httparty (~> 0.21.0)
   importmap-rails
   jbuilder
@@ -314,6 +321,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails
+  timecop
   turbo-rails
   tzinfo-data
   web-console

--- a/README.md
+++ b/README.md
@@ -4,17 +4,4 @@ This project should obtain your location and tell you the current weather
 * Ruby version
 3.0.6
 * System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+Set envirorment variables for WEATHER_API_BASE and the WEATHER_API_ACCESS_TOKEN

--- a/app/models/stored_response.rb
+++ b/app/models/stored_response.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class StoredResponse < ApplicationRecord
+  validates :api_client,
+            :method_name,
+            :params_hash,
+            :api_response,
+            :valid_until, presence: true
+
+  def valid_response
+    persisted? && valid_until > 1.hour.ago
+  end
+end

--- a/db/migrate/20240929032656_create_stored_responses.rb
+++ b/db/migrate/20240929032656_create_stored_responses.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateStoredResponses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stored_responses do |t|
+      t.string :api_client, null: false
+      t.string :method_name, null: false
+      t.json :params_hash, null: false
+      t.json :api_response, null: false
+      t.datetime :valid_until, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2024_09_29_032656) do
+  create_table "stored_responses", force: :cascade do |t|
+    t.string "api_client", null: false
+    t.string "method_name", null: false
+    t.json "params_hash", null: false
+    t.json "api_response", null: false
+    t.datetime "valid_until", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/factories/stored_responses.rb
+++ b/spec/factories/stored_responses.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :stored_response, class: StoredResponse do
+    params_hash { { lat: 1, lon: 1 } }
+    api_client { 'Weather::ApiClientService' }
+    method_name { 'query_by_position' }
+    valid_until { 1.hour.from_now }
+    api_response { {} }
+  end
+end

--- a/spec/models/stored_response_spec.rb
+++ b/spec/models/stored_response_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StoredResponse, type: :model do
+  describe 'validations' do
+    it 'checks presence', factory: :stub do
+      expect(subject).to validate_presence_of(:api_client)
+      expect(subject).to validate_presence_of(:method_name)
+      expect(subject).to validate_presence_of(:params_hash)
+      expect(subject).to validate_presence_of(:api_response)
+      expect(subject).to validate_presence_of(:valid_until)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.include FactoryBot::Syntax::Methods
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -113,4 +114,11 @@ Capybara.configure do |config|
   config.javascript_driver = :chrome
   config.server = :puma, { Silent: true }
   config.server_host = '0.0.0.0'
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end


### PR DESCRIPTION
When I first implemented the cache I misread the description of the requirement, it clearly said that we needed to use the db, I think that we should implement a task that cleans old responses because latitude and longitude params can change a lot and we don't really need responses from weeks/months/years ago